### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "docker:build": "docker build -t imbo/face-detector .",
     "docker:push": "docker push imbo/face-detector"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/imbo/imbo-face-detector.git"
+  },
   "bin": {
     "imbo-face-detector": "./bin/consumer.js"
   },


### PR DESCRIPTION
The `repository` field was missing from `package.json`, causing some annoying warnings during installation.
