### PR TITLE
Add http server with health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,8 @@ RUN cd /app && npm install
 COPY . /app
 WORKDIR /app
 
+# Expose health check port
+EXPOSE 8888 8888
+
 # Start application
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The configuration of the application is done either by setting environment varia
 - `AMQP_EXCHANGE` - Name of exchange to use. Default: `imbo`
 - `AMQP_NOACK` - Whether or not to use `noAck` mode for messages. Default: `true`
 
+### Health check
+
+- `HTTP_PORT` - Port for health check server. Default: `8888`
+
 ## Configuration file
 
 Should you instead want to use a configuration file, simply create a JSON file with any or all of the options below, and specify the path to the file with the `--config` option. The configuration will be recursively merged with the default values.

--- a/bin/consumer.js
+++ b/bin/consumer.js
@@ -1,11 +1,26 @@
 #!/usr/bin/env node
 'use strict';
 
+var http = require('http');
+
 var amqpClient = require('amqplib/callback_api');
 var detectFaces = require('../lib/detect-faces');
 var config = require('../config/config');
 var imboClient = require('../lib/imbo-client');
 var unique = require('lodash.uniq');
+
+// Set up http server for healt checks
+var healthCheckPort = process.env.HTTP_PORT || 8888;
+
+http.createServer(function(req, res) {
+    if (req.url !== '/status') {
+        res.writeHead(404);
+    }
+
+    return res.end('');
+}).listen(healthCheckPort);
+
+log('Healt check server listening on port ' + healthCheckPort);
 
 // Variables that are changed during the setup process
 var channel, queueName;


### PR DESCRIPTION
In order to get this up and running with marathon we need a health check endpoint. This PR adds that and exposes it from the docker container on port 8888.
